### PR TITLE
Bump MSRV to 1.83 and update workflows

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        msrv: ["1.79"] # We're relying on namespaced-features, which
+        msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -215,6 +215,8 @@ jobs:
                        #
                        # embassy-time requires 1.79 due to
                        # collapse_debuginfo
+                       #
+                       # bitfield-struct requires 1.83
     name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
     steps:
       - uses: actions/checkout@v4
@@ -227,4 +229,3 @@ jobs:
           toolchain: ${{ matrix.msrv }}
       - name: cargo +${{ matrix.msrv }} check
         run: cargo check
-        

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -204,7 +204,7 @@ jobs:
       fail-fast: false
       matrix:
         commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        msrv: ["1.79"] # We're relying on namespaced-features, which
+        msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
                        # We also depend on `fixed' which requires rust
@@ -215,6 +215,8 @@ jobs:
                        #
                        # embassy-time requires 1.79 due to
                        # collapse_debuginfo
+                       #
+                       # bitfield-struct requires 1.83
     name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
     steps:
       - uses: actions/checkout@v4

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Drivers for fuel gauges and charging controllers should implement these traits t
 
 ## MSRV
 
-Currently, rust `1.81` and up is supported.
+Currently, rust `1.83` and up is supported.
 
 ## License
 

--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -16,3 +16,4 @@ defmt = ["dep:defmt"]
 embedded-batteries = { path = "../embedded-batteries"}
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
+bitfield-struct = "0.10"

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -15,3 +15,4 @@ defmt = ["dep:defmt"]
 [dependencies]
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
+bitfield-struct = "0.10"


### PR DESCRIPTION
needed for [bitfield-struct](https://github.com/wrenger/bitfield-struct-rs/blob/34a1aea3ea01e8720c5c36a987efb5267d0c0c03/Cargo.toml#L13) support.