### PR TITLE
Add embedded-batteries defmt dependency to async embedded batteries defmt feature

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -10,10 +10,10 @@ readme = "README.md"
 repository = "https://github.com/OpenDevicePartnership/embedded-batteries"
 
 [features]
-defmt = ["dep:defmt"]
+defmt = ["dep:defmt", "embedded-batteries/defmt"]
 
 [dependencies]
-embedded-batteries = { path = "../embedded-batteries"}
+embedded-batteries = { path = "../embedded-batteries" }
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
 bitfield-struct = "0.10"


### PR DESCRIPTION
When using embedded-batteries-async's `defmt` feature, the enums and structs pulled in from `embedded-batteries` do not derive `defmt` because we don't pull that in as a dependency. This fixes the problem by pulling in `embedded-batteries`'s `defmt` feature when `embedded-batteries-async` uses `defmt`.