### PR TITLE
pull embedded-batteries from crates.io

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -15,7 +15,7 @@ repository = "https://github.com/OpenDevicePartnership/embedded-batteries"
 defmt = ["dep:defmt", "embedded-batteries/defmt"]
 
 [dependencies]
-embedded-batteries = { version = "0.1.0", path = "../embedded-batteries" }
+embedded-batteries = "0.1.0"
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
 bitfield-struct = "0.10"


### PR DESCRIPTION
Now that the crate is published, we want to enforce use of the ABI compatible versions.