### PR TITLE
Various ACPI message improvements

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries-async"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries"
-version = "0.2.0"
+version = "0.2.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
@@ -19,3 +19,4 @@ embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
 bitfield-struct = "0.10"
 bitflags = "2.9"
+zerocopy = { version = "0.8", features = ["derive"] }


### PR DESCRIPTION
Changelog:
- Add default and zerocopy derives to ACPI messages where possible
- Add STA return type
- Add manual serialize fns to BIX and PIF message structs
- Change ascii strings stored in BIX and PIF to immutable ref