### PR TITLE
Remove blanket impl for &mut T and add wrapper macro

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries-async"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries"
-version = "0.2.1"
+version = "0.3.0"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]


### PR DESCRIPTION
- Types that wrap an object that implements SmartBattery are common, and having to impl SmartBattery for the wrapper results in lots of boilerplate. This change adds a macro to reduce boilerplate.
- Uprev to v0.3.0

Resolves #26 