### PR TITLE
Fix clippy warning in macro

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries-async"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
@@ -15,7 +15,7 @@ repository = "https://github.com/OpenDevicePartnership/embedded-batteries"
 defmt = ["dep:defmt", "embedded-batteries/defmt"]
 
 [dependencies]
-embedded-batteries = "0.2.0"
+embedded-batteries = "0.3"
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
 bitfield-struct = "0.10"

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries"
-version = "0.3.0"
+version = "0.3.1"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/embedded-batteries/src/smart_battery.rs
+++ b/embedded-batteries/src/smart_battery.rs
@@ -824,163 +824,163 @@ macro_rules! impl_smart_battery_for_wrapper_type {
             fn remaining_capacity_alarm(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                Ok(self.$inner.remaining_capacity_alarm()?)
+                self.$inner.remaining_capacity_alarm()
             }
 
             fn set_remaining_capacity_alarm(
                 &mut self,
                 capacity: embedded_batteries::smart_battery::CapacityModeValue,
             ) -> Result<(), Self::Error> {
-                Ok(self.$inner.set_remaining_capacity_alarm(capacity)?)
+                self.$inner.set_remaining_capacity_alarm(capacity)
             }
 
             fn remaining_time_alarm(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.remaining_time_alarm()?)
+                self.$inner.remaining_time_alarm()
             }
 
             fn set_remaining_time_alarm(
                 &mut self,
                 time: embedded_batteries::smart_battery::Minutes,
             ) -> Result<(), Self::Error> {
-                Ok(self.$inner.set_remaining_time_alarm(time)?)
+                self.$inner.set_remaining_time_alarm(time)
             }
 
             fn battery_mode(&mut self) -> Result<embedded_batteries::smart_battery::BatteryModeFields, Self::Error> {
-                Ok(self.$inner.battery_mode()?)
+                self.$inner.battery_mode()
             }
 
             fn set_battery_mode(
                 &mut self,
                 flags: embedded_batteries::smart_battery::BatteryModeFields,
             ) -> Result<(), Self::Error> {
-                Ok(self.$inner.set_battery_mode(flags)?)
+                self.$inner.set_battery_mode(flags)
             }
 
             fn at_rate(&mut self) -> Result<embedded_batteries::smart_battery::CapacityModeSignedValue, Self::Error> {
-                Ok(self.$inner.at_rate()?)
+                self.$inner.at_rate()
             }
 
             fn set_at_rate(
                 &mut self,
                 rate: embedded_batteries::smart_battery::CapacityModeSignedValue,
             ) -> Result<(), Self::Error> {
-                Ok(self.$inner.set_at_rate(rate)?)
+                self.$inner.set_at_rate(rate)
             }
 
             fn at_rate_time_to_full(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.at_rate_time_to_full()?)
+                self.$inner.at_rate_time_to_full()
             }
 
             fn at_rate_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.at_rate_time_to_empty()?)
+                self.$inner.at_rate_time_to_empty()
             }
 
             fn at_rate_ok(&mut self) -> Result<bool, Self::Error> {
-                Ok(self.$inner.at_rate_ok()?)
+                self.$inner.at_rate_ok()
             }
 
             fn temperature(&mut self) -> Result<embedded_batteries::smart_battery::DeciKelvin, Self::Error> {
-                Ok(self.$inner.temperature()?)
+                self.$inner.temperature()
             }
 
             fn voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                Ok(self.$inner.voltage()?)
+                self.$inner.voltage()
             }
 
             fn current(&mut self) -> Result<embedded_batteries::smart_battery::MilliAmpsSigned, Self::Error> {
-                Ok(self.$inner.current()?)
+                self.$inner.current()
             }
 
             fn average_current(&mut self) -> Result<embedded_batteries::smart_battery::MilliAmpsSigned, Self::Error> {
-                Ok(self.$inner.average_current()?)
+                self.$inner.average_current()
             }
 
             fn max_error(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                Ok(self.$inner.max_error()?)
+                self.$inner.max_error()
             }
 
             fn relative_state_of_charge(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                Ok(self.$inner.relative_state_of_charge()?)
+                self.$inner.relative_state_of_charge()
             }
 
             fn absolute_state_of_charge(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                Ok(self.$inner.absolute_state_of_charge()?)
+                self.$inner.absolute_state_of_charge()
             }
 
             fn remaining_capacity(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                Ok(self.$inner.remaining_capacity()?)
+                self.$inner.remaining_capacity()
             }
 
             fn full_charge_capacity(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                Ok(self.$inner.full_charge_capacity()?)
+                self.$inner.full_charge_capacity()
             }
 
             fn run_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.run_time_to_empty()?)
+                self.$inner.run_time_to_empty()
             }
 
             fn average_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.average_time_to_empty()?)
+                self.$inner.average_time_to_empty()
             }
 
             fn average_time_to_full(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                Ok(self.$inner.average_time_to_full()?)
+                self.$inner.average_time_to_full()
             }
 
             fn charging_current(&mut self) -> Result<embedded_batteries::charger::MilliAmps, Self::Error> {
-                Ok(self.$inner.charging_current()?)
+                self.$inner.charging_current()
             }
 
             fn charging_voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                Ok(self.$inner.charging_voltage()?)
+                self.$inner.charging_voltage()
             }
 
             fn battery_status(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::BatteryStatusFields, Self::Error> {
-                Ok(self.$inner.battery_status()?)
+                self.$inner.battery_status()
             }
 
             fn cycle_count(&mut self) -> Result<embedded_batteries::smart_battery::Cycles, Self::Error> {
-                Ok(self.$inner.cycle_count()?)
+                self.$inner.cycle_count()
             }
 
             fn design_capacity(&mut self) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                Ok(self.$inner.design_capacity()?)
+                self.$inner.design_capacity()
             }
 
             fn design_voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                Ok(self.$inner.design_voltage()?)
+                self.$inner.design_voltage()
             }
 
             fn specification_info(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::SpecificationInfoFields, Self::Error> {
-                Ok(self.$inner.specification_info()?)
+                self.$inner.specification_info()
             }
 
             fn manufacture_date(&mut self) -> Result<embedded_batteries::smart_battery::ManufactureDate, Self::Error> {
-                Ok(self.$inner.manufacture_date()?)
+                self.$inner.manufacture_date()
             }
 
             fn serial_number(&mut self) -> Result<u16, Self::Error> {
-                Ok(self.$inner.serial_number()?)
+                self.$inner.serial_number()
             }
 
             fn manufacturer_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                Ok(self.$inner.manufacturer_name(name)?)
+                self.$inner.manufacturer_name(name)
             }
 
             fn device_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                Ok(self.$inner.device_name(name)?)
+                self.$inner.device_name(name)
             }
 
             fn device_chemistry(&mut self, chemistry: &mut [u8]) -> Result<(), Self::Error> {
-                Ok(self.$inner.device_chemistry(chemistry)?)
+                self.$inner.device_chemistry(chemistry)
             }
         }
     };


### PR DESCRIPTION
Fix clippy warning hidden in `impl_smart_battery_for_wrapper_type!()`.

Uprev to v0.3.1