### PR TITLE
Fix missed ? operator in async macro

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries-async"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]

--- a/embedded-batteries-async/src/smart_battery.rs
+++ b/embedded-batteries-async/src/smart_battery.rs
@@ -356,7 +356,7 @@ macro_rules! impl_smart_battery_for_wrapper_type {
             async fn remaining_capacity_alarm(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.remaining_capacity_alarm().await?
+                self.$inner.remaining_capacity_alarm().await
             }
 
             async fn set_remaining_capacity_alarm(

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries"
-version = "0.3.2"
+version = "0.3.3"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]


### PR DESCRIPTION
Somehow missed this one `?` operator when making #36, causing any builds with the macro to fail. Already yanked the crate from crates.io and this will be v0.3.3. Verified by patching my local version of a downstream crate and constructing the macro.