### PR TITLE
Add clippy allow to smart battery macro and uprev bitfield-struct

### DIFF
--- a/embedded-batteries-async/Cargo.toml
+++ b/embedded-batteries-async/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries-async"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
@@ -18,4 +18,4 @@ defmt = ["dep:defmt", "embedded-batteries/defmt"]
 embedded-batteries = "0.3"
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
-bitfield-struct = "0.10"
+bitfield-struct = "0.12"

--- a/embedded-batteries-async/src/smart_battery.rs
+++ b/embedded-batteries-async/src/smart_battery.rs
@@ -352,197 +352,198 @@ macro_rules! impl_smart_battery_for_wrapper_type {
             type Error = $error;
         }
 
+        #[allow(clippy::needless_question_mark)]
         impl embedded_batteries_async::smart_battery::SmartBattery for $wrapper {
             async fn remaining_capacity_alarm(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.remaining_capacity_alarm().await
+                Ok(self.$inner.remaining_capacity_alarm().await?)
             }
 
             async fn set_remaining_capacity_alarm(
                 &mut self,
                 capacity: embedded_batteries_async::smart_battery::CapacityModeValue,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_remaining_capacity_alarm(capacity).await
+                Ok(self.$inner.set_remaining_capacity_alarm(capacity).await?)
             }
 
             async fn remaining_time_alarm(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.remaining_time_alarm().await
+                Ok(self.$inner.remaining_time_alarm().await?)
             }
 
             async fn set_remaining_time_alarm(
                 &mut self,
                 time: embedded_batteries_async::smart_battery::Minutes,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_remaining_time_alarm(time).await
+                Ok(self.$inner.set_remaining_time_alarm(time).await?)
             }
 
             async fn battery_mode(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::BatteryModeFields, Self::Error> {
-                self.$inner.battery_mode().await
+                Ok(self.$inner.battery_mode().await?)
             }
 
             async fn set_battery_mode(
                 &mut self,
                 flags: embedded_batteries_async::smart_battery::BatteryModeFields,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_battery_mode(flags).await
+                Ok(self.$inner.set_battery_mode(flags).await?)
             }
 
             async fn at_rate(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeSignedValue, Self::Error> {
-                self.$inner.at_rate().await
+                Ok(self.$inner.at_rate().await?)
             }
 
             async fn set_at_rate(
                 &mut self,
                 rate: embedded_batteries_async::smart_battery::CapacityModeSignedValue,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_at_rate(rate).await
+                Ok(self.$inner.set_at_rate(rate).await?)
             }
 
             async fn at_rate_time_to_full(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.at_rate_time_to_full().await
+                Ok(self.$inner.at_rate_time_to_full().await?)
             }
 
             async fn at_rate_time_to_empty(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.at_rate_time_to_empty().await
+                Ok(self.$inner.at_rate_time_to_empty().await?)
             }
 
             async fn at_rate_ok(&mut self) -> Result<bool, Self::Error> {
-                self.$inner.at_rate_ok().await
+                Ok(self.$inner.at_rate_ok().await?)
             }
 
             async fn temperature(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::DeciKelvin, Self::Error> {
-                self.$inner.temperature().await
+                Ok(self.$inner.temperature().await?)
             }
 
             async fn voltage(&mut self) -> Result<embedded_batteries_async::charger::MilliVolts, Self::Error> {
-                self.$inner.voltage().await
+                Ok(self.$inner.voltage().await?)
             }
 
             async fn current(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::MilliAmpsSigned, Self::Error> {
-                self.$inner.current().await
+                Ok(self.$inner.current().await?)
             }
 
             async fn average_current(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::MilliAmpsSigned, Self::Error> {
-                self.$inner.average_current().await
+                Ok(self.$inner.average_current().await?)
             }
 
             async fn max_error(&mut self) -> Result<embedded_batteries_async::smart_battery::Percent, Self::Error> {
-                self.$inner.max_error().await
+                Ok(self.$inner.max_error().await?)
             }
 
             async fn relative_state_of_charge(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Percent, Self::Error> {
-                self.$inner.relative_state_of_charge().await
+                Ok(self.$inner.relative_state_of_charge().await?)
             }
 
             async fn absolute_state_of_charge(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Percent, Self::Error> {
-                self.$inner.absolute_state_of_charge().await
+                Ok(self.$inner.absolute_state_of_charge().await?)
             }
 
             async fn remaining_capacity(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.remaining_capacity().await
+                Ok(self.$inner.remaining_capacity().await?)
             }
 
             async fn full_charge_capacity(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.full_charge_capacity().await
+                Ok(self.$inner.full_charge_capacity().await?)
             }
 
             async fn run_time_to_empty(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.run_time_to_empty().await
+                Ok(self.$inner.run_time_to_empty().await?)
             }
 
             async fn average_time_to_empty(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.average_time_to_empty().await
+                Ok(self.$inner.average_time_to_empty().await?)
             }
 
             async fn average_time_to_full(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::Minutes, Self::Error> {
-                self.$inner.average_time_to_full().await
+                Ok(self.$inner.average_time_to_full().await?)
             }
 
             async fn charging_current(&mut self) -> Result<embedded_batteries_async::charger::MilliAmps, Self::Error> {
-                self.$inner.charging_current().await
+                Ok(self.$inner.charging_current().await?)
             }
 
             async fn charging_voltage(&mut self) -> Result<embedded_batteries_async::charger::MilliVolts, Self::Error> {
-                self.$inner.charging_voltage().await
+                Ok(self.$inner.charging_voltage().await?)
             }
 
             async fn battery_status(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::BatteryStatusFields, Self::Error> {
-                self.$inner.battery_status().await
+                Ok(self.$inner.battery_status().await?)
             }
 
             async fn cycle_count(&mut self) -> Result<embedded_batteries_async::smart_battery::Cycles, Self::Error> {
-                self.$inner.cycle_count().await
+                Ok(self.$inner.cycle_count().await?)
             }
 
             async fn design_capacity(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.design_capacity().await
+                Ok(self.$inner.design_capacity().await?)
             }
 
             async fn design_voltage(&mut self) -> Result<embedded_batteries_async::charger::MilliVolts, Self::Error> {
-                self.$inner.design_voltage().await
+                Ok(self.$inner.design_voltage().await?)
             }
 
             async fn specification_info(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::SpecificationInfoFields, Self::Error> {
-                self.$inner.specification_info().await
+                Ok(self.$inner.specification_info().await?)
             }
 
             async fn manufacture_date(
                 &mut self,
             ) -> Result<embedded_batteries_async::smart_battery::ManufactureDate, Self::Error> {
-                self.$inner.manufacture_date().await
+                Ok(self.$inner.manufacture_date().await?)
             }
 
             async fn serial_number(&mut self) -> Result<u16, Self::Error> {
-                self.$inner.serial_number().await
+                Ok(self.$inner.serial_number().await?)
             }
 
             async fn manufacturer_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.manufacturer_name(name).await
+                Ok(self.$inner.manufacturer_name(name).await?)
             }
 
             async fn device_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.device_name(name).await
+                Ok(self.$inner.device_name(name).await?)
             }
 
             async fn device_chemistry(&mut self, chemistry: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.device_chemistry(chemistry).await
+                Ok(self.$inner.device_chemistry(chemistry).await?)
             }
         }
     };

--- a/embedded-batteries/Cargo.toml
+++ b/embedded-batteries/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "embedded-batteries"
-version = "0.3.3"
+version = "0.3.4"
 edition = "2021"
 rust-version = "1.83"
 authors = ["Matteo Tullo <matteotullo@microsoft.com>"]
@@ -17,6 +17,6 @@ defmt = ["dep:defmt"]
 [dependencies]
 embedded-hal = "1.0.0"
 defmt = { version = "0.3", optional = true }
-bitfield-struct = "0.10"
+bitfield-struct = "0.12"
 bitflags = "2.9"
 zerocopy = { version = "0.8", features = ["derive"] }

--- a/embedded-batteries/src/smart_battery.rs
+++ b/embedded-batteries/src/smart_battery.rs
@@ -820,167 +820,168 @@ macro_rules! impl_smart_battery_for_wrapper_type {
             type Error = $error;
         }
 
+        #[allow(clippy::needless_question_mark)]
         impl embedded_batteries::smart_battery::SmartBattery for $wrapper {
             fn remaining_capacity_alarm(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.remaining_capacity_alarm()
+                Ok(self.$inner.remaining_capacity_alarm()?)
             }
 
             fn set_remaining_capacity_alarm(
                 &mut self,
                 capacity: embedded_batteries::smart_battery::CapacityModeValue,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_remaining_capacity_alarm(capacity)
+                Ok(self.$inner.set_remaining_capacity_alarm(capacity)?)
             }
 
             fn remaining_time_alarm(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.remaining_time_alarm()
+                Ok(self.$inner.remaining_time_alarm()?)
             }
 
             fn set_remaining_time_alarm(
                 &mut self,
                 time: embedded_batteries::smart_battery::Minutes,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_remaining_time_alarm(time)
+                Ok(self.$inner.set_remaining_time_alarm(time)?)
             }
 
             fn battery_mode(&mut self) -> Result<embedded_batteries::smart_battery::BatteryModeFields, Self::Error> {
-                self.$inner.battery_mode()
+                Ok(self.$inner.battery_mode()?)
             }
 
             fn set_battery_mode(
                 &mut self,
                 flags: embedded_batteries::smart_battery::BatteryModeFields,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_battery_mode(flags)
+                Ok(self.$inner.set_battery_mode(flags)?)
             }
 
             fn at_rate(&mut self) -> Result<embedded_batteries::smart_battery::CapacityModeSignedValue, Self::Error> {
-                self.$inner.at_rate()
+                Ok(self.$inner.at_rate()?)
             }
 
             fn set_at_rate(
                 &mut self,
                 rate: embedded_batteries::smart_battery::CapacityModeSignedValue,
             ) -> Result<(), Self::Error> {
-                self.$inner.set_at_rate(rate)
+                Ok(self.$inner.set_at_rate(rate)?)
             }
 
             fn at_rate_time_to_full(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.at_rate_time_to_full()
+                Ok(self.$inner.at_rate_time_to_full()?)
             }
 
             fn at_rate_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.at_rate_time_to_empty()
+                Ok(self.$inner.at_rate_time_to_empty()?)
             }
 
             fn at_rate_ok(&mut self) -> Result<bool, Self::Error> {
-                self.$inner.at_rate_ok()
+                Ok(self.$inner.at_rate_ok()?)
             }
 
             fn temperature(&mut self) -> Result<embedded_batteries::smart_battery::DeciKelvin, Self::Error> {
-                self.$inner.temperature()
+                Ok(self.$inner.temperature()?)
             }
 
             fn voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                self.$inner.voltage()
+                Ok(self.$inner.voltage()?)
             }
 
             fn current(&mut self) -> Result<embedded_batteries::smart_battery::MilliAmpsSigned, Self::Error> {
-                self.$inner.current()
+                Ok(self.$inner.current()?)
             }
 
             fn average_current(&mut self) -> Result<embedded_batteries::smart_battery::MilliAmpsSigned, Self::Error> {
-                self.$inner.average_current()
+                Ok(self.$inner.average_current()?)
             }
 
             fn max_error(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                self.$inner.max_error()
+                Ok(self.$inner.max_error()?)
             }
 
             fn relative_state_of_charge(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                self.$inner.relative_state_of_charge()
+                Ok(self.$inner.relative_state_of_charge()?)
             }
 
             fn absolute_state_of_charge(&mut self) -> Result<embedded_batteries::smart_battery::Percent, Self::Error> {
-                self.$inner.absolute_state_of_charge()
+                Ok(self.$inner.absolute_state_of_charge()?)
             }
 
             fn remaining_capacity(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.remaining_capacity()
+                Ok(self.$inner.remaining_capacity()?)
             }
 
             fn full_charge_capacity(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.full_charge_capacity()
+                Ok(self.$inner.full_charge_capacity()?)
             }
 
             fn run_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.run_time_to_empty()
+                Ok(self.$inner.run_time_to_empty()?)
             }
 
             fn average_time_to_empty(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.average_time_to_empty()
+                Ok(self.$inner.average_time_to_empty()?)
             }
 
             fn average_time_to_full(&mut self) -> Result<embedded_batteries::smart_battery::Minutes, Self::Error> {
-                self.$inner.average_time_to_full()
+                Ok(self.$inner.average_time_to_full()?)
             }
 
             fn charging_current(&mut self) -> Result<embedded_batteries::charger::MilliAmps, Self::Error> {
-                self.$inner.charging_current()
+                Ok(self.$inner.charging_current()?)
             }
 
             fn charging_voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                self.$inner.charging_voltage()
+                Ok(self.$inner.charging_voltage()?)
             }
 
             fn battery_status(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::BatteryStatusFields, Self::Error> {
-                self.$inner.battery_status()
+                Ok(self.$inner.battery_status()?)
             }
 
             fn cycle_count(&mut self) -> Result<embedded_batteries::smart_battery::Cycles, Self::Error> {
-                self.$inner.cycle_count()
+                Ok(self.$inner.cycle_count()?)
             }
 
             fn design_capacity(&mut self) -> Result<embedded_batteries::smart_battery::CapacityModeValue, Self::Error> {
-                self.$inner.design_capacity()
+                Ok(self.$inner.design_capacity()?)
             }
 
             fn design_voltage(&mut self) -> Result<embedded_batteries::charger::MilliVolts, Self::Error> {
-                self.$inner.design_voltage()
+                Ok(self.$inner.design_voltage()?)
             }
 
             fn specification_info(
                 &mut self,
             ) -> Result<embedded_batteries::smart_battery::SpecificationInfoFields, Self::Error> {
-                self.$inner.specification_info()
+                Ok(self.$inner.specification_info()?)
             }
 
             fn manufacture_date(&mut self) -> Result<embedded_batteries::smart_battery::ManufactureDate, Self::Error> {
-                self.$inner.manufacture_date()
+                Ok(self.$inner.manufacture_date()?)
             }
 
             fn serial_number(&mut self) -> Result<u16, Self::Error> {
-                self.$inner.serial_number()
+                Ok(self.$inner.serial_number()?)
             }
 
             fn manufacturer_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.manufacturer_name(name)
+                Ok(self.$inner.manufacturer_name(name)?)
             }
 
             fn device_name(&mut self, name: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.device_name(name)
+                Ok(self.$inner.device_name(name)?)
             }
 
             fn device_chemistry(&mut self, chemistry: &mut [u8]) -> Result<(), Self::Error> {
-                self.$inner.device_chemistry(chemistry)
+                Ok(self.$inner.device_chemistry(chemistry)?)
             }
         }
     };


### PR DESCRIPTION
There exists an edge case where clippy will fail if the underlying driver's return error type `Result<(), T>` is the same as the associated Error type, meaning that the `Ok(foo()?)` pattern can be simplified to `foo()`. The question mark does a conversion for us if the return type of `foo()` is different from the associated type, and we want this functionality always. Therefore, we allow the clippy lint `clippy::needless_question_mark`

Uprev to v0.3.4