### PR TITLE
Remove per-commit checking from CI workflow

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -1,6 +1,5 @@
 # This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
 # several checks:
-# - commit_list: produces a list of commits to be checked
 # - fmt: checks that the code is formatted according to rustfmt
 # - clippy: checks that the code does not contain any clippy warnings
 # - doc: checks that the code can be documented without errors
@@ -23,47 +22,13 @@ concurrency:
 name: check
 jobs:
 
-  commit_list:
-    runs-on: ubuntu-latest
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Get commit list (push)
-      id: get_commit_list_push
-      if: ${{ github.event_name == 'push' }}
-      run: |
-        echo "id0=$GITHUB_SHA" > $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    - name: Get commit list (PR)
-      id: get_commit_list_pr
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        git rev-list --reverse refs/remotes/origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | awk '{ print "id" NR "=" $1 }' > $GITHUB_OUTPUT
-        git diff --quiet ${{ github.event.pull_request.head.sha }} ${{ github.sha }} || echo "id0=$GITHUB_SHA" >> $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    outputs:
-      commits: ${{ toJSON(steps.*.outputs.*) }}
-
   fmt:
     runs-on: ubuntu-latest
     name: nightly / fmt
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
         with:
@@ -73,8 +38,7 @@ jobs:
 
   clippy:
     runs-on: ubuntu-latest
-    name: ${{ matrix.toolchain }} / clippy (${{ matrix.commit }})
-    needs: commit_list
+    name: ${{ matrix.toolchain }} / clippy
     permissions:
       contents: read
       checks: write
@@ -83,12 +47,10 @@ jobs:
       matrix:
         # Get early warning of new lints which are regularly introduced in beta channels.
         toolchain: [stable, beta]
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.toolchain }}
         uses: dtolnay/rust-toolchain@master
         with:
@@ -105,16 +67,10 @@ jobs:
   semver:
     runs-on: ubuntu-latest
     name: semver
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
         with:
@@ -128,16 +84,10 @@ jobs:
     # API be documented as only available in some specific platforms.
     runs-on: ubuntu-latest
     name: nightly / doc
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install nightly
         uses: dtolnay/rust-toolchain@nightly
       - name: cargo doc
@@ -150,16 +100,10 @@ jobs:
     # which is required for feature unification
     runs-on: ubuntu-latest
     name: ubuntu / stable / features
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-hack
@@ -174,16 +118,10 @@ jobs:
     # our dependencies.
     runs-on: ubuntu-latest
     name: ubuntu / stable / deny
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
       - name: cargo install cargo-deny
@@ -197,13 +135,11 @@ jobs:
   msrv:
     # check that we can build using the minimal rust version that is specified by this crate
     runs-on: ubuntu-latest
-    needs: commit_list
     # we use a matrix here just because env can't be used in job names
     # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
     strategy:
       fail-fast: false
       matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
         msrv: ["1.83"] # We're relying on namespaced-features, which
                        # was released in 1.60
                        #
@@ -217,12 +153,11 @@ jobs:
                        # collapse_debuginfo
                        #
                        # bitfield-struct requires 1.83
-    name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
+    name: ubuntu / ${{ matrix.msrv }}
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install ${{ matrix.msrv }}
         uses: dtolnay/rust-toolchain@master
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,8 +2,10 @@
 # several checks:
 # - fmt: checks that the code is formatted according to rustfmt
 # - clippy: checks that the code does not contain any clippy warnings
+# - semver: checks for semver violations
 # - doc: checks that the code can be documented without errors
 # - hack: check combinations of feature flags
+# - deny: checks licenses, advisories, sources, and bans
 # - msrv: check that the msrv specified in the crate is correct
 permissions:
   contents: read
@@ -63,7 +65,6 @@ jobs:
           clippy_flags: -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
           github_token: ${{ secrets.GITHUB_TOKEN }}
 
-  # Enable once we have a released crate
   semver:
     runs-on: ubuntu-latest
     name: semver

--- a/.github/workflows/nostd.yml
+++ b/.github/workflows/nostd.yml
@@ -1,231 +1,30 @@
-# This workflow runs whenever a PR is opened or updated, or a commit is pushed to main. It runs
-# several checks:
-# - commit_list: produces a list of commits to be checked
-# - fmt: checks that the code is formatted according to rustfmt
-# - clippy: checks that the code does not contain any clippy warnings
-# - doc: checks that the code can be documented without errors
-# - hack: check combinations of feature flags
-# - msrv: check that the msrv specified in the crate is correct
+# This workflow checks whether the library is able to run without the std library (e.g., embedded).
+# This entire file should be removed if this crate does not support no-std. See check.yml for
+# information about how the concurrency cancellation and workflow triggering works
 permissions:
   contents: read
-# This configuration allows maintainers of this repo to create a branch and pull request based on
-# the new branch. Restricting the push trigger to the main branch ensures that the PR only gets
-# built once.
 on:
   push:
     branches: [main]
   pull_request:
-# If new code is pushed to a PR branch, then cancel in progress workflows for that PR. Ensures that
-# we don't waste CI time, and returns results quicker https://github.com/jonhoo/rust-ci-conf/pull/5
 concurrency:
   group: ${{ github.workflow }}-${{ github.head_ref || github.run_id }}
   cancel-in-progress: true
-name: check
+name: no-std
 jobs:
-
-  commit_list:
+  nostd:
     runs-on: ubuntu-latest
-    steps:
-
-    - uses: actions/checkout@v4
-      with:
-        fetch-depth: 0
-
-    - name: Get commit list (push)
-      id: get_commit_list_push
-      if: ${{ github.event_name == 'push' }}
-      run: |
-        echo "id0=$GITHUB_SHA" > $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    - name: Get commit list (PR)
-      id: get_commit_list_pr
-      if: ${{ github.event_name == 'pull_request' }}
-      run: |
-        git rev-list --reverse refs/remotes/origin/${{ github.base_ref }}..${{ github.event.pull_request.head.sha }} | awk '{ print "id" NR "=" $1 }' > $GITHUB_OUTPUT
-        git diff --quiet ${{ github.event.pull_request.head.sha }} ${{ github.sha }} || echo "id0=$GITHUB_SHA" >> $GITHUB_OUTPUT
-        echo "List of tested commits:" > $GITHUB_STEP_SUMMARY
-        sed -n 's,^id[0-9]\+=\(.*\),- ${{ github.repositoryUrl }}/commit/\1,p' -- $GITHUB_OUTPUT >> $GITHUB_STEP_SUMMARY
-
-    outputs:
-      commits: ${{ toJSON(steps.*.outputs.*) }}
-
-  fmt:
-    runs-on: ubuntu-latest
-    name: nightly / fmt
-    needs: commit_list
+    name: ${{ matrix.target }}
     strategy:
-      fail-fast: false
       matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
+        target: [thumbv8m.main-none-eabihf]
     steps:
       - uses: actions/checkout@v4
         with:
           submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install nightly
-        uses: dtolnay/rust-toolchain@nightly
-        with:
-          components: rustfmt
-      - name: cargo fmt --check
-        run: cargo fmt --check
-
-  clippy:
-    runs-on: ubuntu-latest
-    name: ${{ matrix.toolchain }} / clippy (${{ matrix.commit }})
-    needs: commit_list
-    permissions:
-      contents: read
-      checks: write
-    strategy:
-      fail-fast: false
-      matrix:
-        # Get early warning of new lints which are regularly introduced in beta channels.
-        toolchain: [stable, beta]
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install ${{ matrix.toolchain }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.toolchain }}
-          components: clippy
-      - name: cargo clippy
-        uses: giraffate/clippy-action@v1
-        with:
-          reporter: 'github-pr-check'
-          clippy_flags: -- -F clippy::suspicious -F clippy::correctness -F clippy::perf -F clippy::style
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-
-  # Enable once we have a released crate
-  semver:
-    runs-on: ubuntu-latest
-    name: semver
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
       - name: Install stable
         uses: dtolnay/rust-toolchain@stable
-        with:
-          components: rustfmt
-      - name: cargo-semver-checks
-        uses: obi1kenobi/cargo-semver-checks-action@v2
-
-  doc:
-    # run docs generation on nightly rather than stable. This enables features like
-    # https://doc.rust-lang.org/beta/unstable-book/language-features/doc-cfg.html which allows an
-    # API be documented as only available in some specific platforms.
-    runs-on: ubuntu-latest
-    name: nightly / doc
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install nightly
-        uses: dtolnay/rust-toolchain@nightly
-      - name: cargo doc
-        run: cargo doc --no-deps --all-features
-        env:
-          RUSTDOCFLAGS: --cfg docsrs
-
-  hack:
-    # cargo-hack checks combinations of feature flags to ensure that features are all additive
-    # which is required for feature unification
-    runs-on: ubuntu-latest
-    name: ubuntu / stable / features
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo install cargo-hack
-        uses: taiki-e/install-action@cargo-hack
-      # intentionally no target specifier; see https://github.com/jonhoo/rust-ci-conf/pull/4
-      # --feature-powerset runs for every combination of features
-      - name: cargo hack
-        run: cargo hack --feature-powerset check
-
-  deny:
-    # cargo-deny checks licenses, advisories, sources, and bans for
-    # our dependencies.
-    runs-on: ubuntu-latest
-    name: ubuntu / stable / deny
-    needs: commit_list
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install stable
-        uses: dtolnay/rust-toolchain@stable
-      - name: cargo install cargo-deny
-        uses: EmbarkStudios/cargo-deny-action@v2
-        with:
-          log-level: warn
-          manifest-path: ./Cargo.toml
-          command: check
-          arguments: --all-features
-
-  msrv:
-    # check that we can build using the minimal rust version that is specified by this crate
-    runs-on: ubuntu-latest
-    needs: commit_list
-    # we use a matrix here just because env can't be used in job names
-    # https://docs.github.com/en/actions/learn-github-actions/contexts#context-availability
-    strategy:
-      fail-fast: false
-      matrix:
-        commit: ${{ fromJSON(needs.commit_list.outputs.commits) }}
-        msrv: ["1.83"] # We're relying on namespaced-features, which
-                       # was released in 1.60
-                       #
-                       # We also depend on `fixed' which requires rust
-                       # 1.71
-                       #
-                       # Additionally, we depend on embedded-hal-async
-                       # which requires 1.75
-                       #
-                       # embassy-time requires 1.79 due to
-                       # collapse_debuginfo
-                       #
-                       # bitfield-struct requires 1.83
-    name: ubuntu / ${{ matrix.msrv }} (${{ matrix.commit }})
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          submodules: true
-          ref: ${{ matrix.commit }}
-      - name: Install ${{ matrix.msrv }}
-        uses: dtolnay/rust-toolchain@master
-        with:
-          toolchain: ${{ matrix.msrv }}
-      - name: cargo +${{ matrix.msrv }} check
-        run: cargo check
+      - name: rustup target add ${{ matrix.target }}
+        run: rustup target add ${{ matrix.target }}
+      - name: cargo check
+        run: cargo check --target ${{ matrix.target }} --no-default-features


### PR DESCRIPTION
Remove the commit_list job and all per-commit matrix strategies from the check workflow. Each CI job now runs once against the PR head or push ref instead of iterating over every individual commit.

This simplifies the workflow and reduces CI resource usage.

Assisted-by: GitHub Copilot:claude-opus-4.6